### PR TITLE
i1744 - add rJava / ReportRs to the orderly image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,10 +31,10 @@ RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pando
 # system dependencies required to install and run R packages (in
 # alphabetical order)
 RUN apt-get update && apt-get install -y \
+  default-jdk \
   libcurl4-openssl-dev \
   libmagick++-dev \
-  libxml2-dev \
-  openjdk-8-jdk
+  libxml2-dev
 
 # Add new packages here (in alphabetical order)
 RUN install2.r --error \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,8 @@ RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pando
 RUN apt-get update && apt-get install -y \
   libcurl4-openssl-dev \
   libmagick++-dev \
-  libxml2-dev
+  libxml2-dev \
+  apt-get install openjdk-8-jdk
 
 # Add new packages here (in alphabetical order)
 RUN install2.r --error \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,7 @@ RUN install2.r --error \
   markdown \
   pander \
   readxl \
+  rJava \
   spelling \
   tidyr
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,9 @@ RUN apt-get update && apt-get install -y \
   libmagick++-dev \
   libxml2-dev
 
+# This is needed so that rJava can find the interpreter correctly
+RUN R CMD javareconf
+
 # Add new packages here (in alphabetical order)
 RUN install2.r --error \
   RColorBrewer \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
   libcurl4-openssl-dev \
   libmagick++-dev \
   libxml2-dev \
-  apt-get install openjdk-8-jdk
+  openjdk-8-jdk
 
 # Add new packages here (in alphabetical order)
 RUN install2.r --error \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,7 @@ RUN R CMD javareconf
 RUN install2.r --error \
   RColorBrewer \
   RcppRoll \
+  ReporteRs \
   captioner \
   dplyr \
   drat \
@@ -55,7 +56,6 @@ RUN install2.r --error \
   markdown \
   pander \
   readxl \
-  rJava \
   spelling \
   tidyr
 


### PR DESCRIPTION
This adds the packages you need to the orderly image.

Things to be aware of here: I have tried to follow the dockerfile best practices as much as possible: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ so everything is alphabetical

One could make a case that the `javareconf` line belongs in the same run that installs the jdk