### PR TITLE
i1807: Update timezone to London localtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,6 +59,7 @@ ARG GIT_ID='UNKNOWN'
 ARG GIT_BRANCH='UNKNOWN'
 ENV ORDERLY_MONTAGU_GIT_HASH $GIT_ID
 ENV ORDERLY_MONTAGU_GIT_BRANCH $GIT_BRANCH
+ENV TZ=Europe/London
 
 COPY docker/orderly_config.yml /etc/montagu/orderly_config.yml
 COPY docker/orderly_init /usr/bin/orderly_init


### PR DESCRIPTION
This will improve the generated ids to align more closely to clocktime

Test with:

```
$ docker run --entrypoint Rscript --rm docker.montagu.dide.ic.ac.uk:5000/montagu-orderly:master -e 'orderly:::new_report_id()'
[1] "20180618-154918-0641a30a"
$ docker run --entrypoint Rscript --rm docker.montagu.dide.ic.ac.uk:5000/montagu-orderly:i1807 -e 'orderly:::new_report_id()'
[1] "20180618-164925-0a99298e"
```