### PR TITLE
i2509: Install jenner into container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,9 @@ RUN install2.r --error \
   spelling \
   tidyr
 
+COPY docker/install_jenner /tmp/install_jenner
+RUN /tmp/install_jenner && rm -f /tmp/install_jenner
+
 ARG GIT_ID='UNKNOWN'
 ARG GIT_BRANCH='UNKNOWN'
 ENV ORDERLY_MONTAGU_GIT_HASH $GIT_ID

--- a/docker/install_jenner
+++ b/docker/install_jenner
@@ -1,0 +1,5 @@
+#!/usr/bin/env Rscript
+drat:::add("vimc")
+install.packages("jenner")
+library(jenner)
+invisible(NULL)

--- a/docker/install_jenner
+++ b/docker/install_jenner
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
 drat:::add("vimc")
-install.packages("jenner")
+install.packages(c("montagu", "jenner"))
 library(jenner)
 invisible(NULL)


### PR DESCRIPTION
This removes the currently manual step of installing `jenner` after a deploy.