### PR TITLE
vimc-4134: install newer node

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM vimc/orderly.server:master
 # install npm
 RUN apt-get update && \
   apt-get -y install curl gnupg && \
-  curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
   apt-get -y install nodejs npm
 
 # Install LaTeX

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,12 +2,9 @@ FROM vimc/orderly.server:master
 
 # install npm
 RUN apt-get update && \
-  apt-get -y install curl gnupg && \
-  apt remove --purge nodejs npm && \
-  apt autoclean && \
-  apt install -f && \
-  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-  apt-get -y install nodejs npm
+  apt-get install -y \
+    nodejs \
+    npm
 
 # Install LaTeX
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM vimc/orderly.server:master
 # install npm
 RUN apt-get update && \
   apt-get -y install curl gnupg && \
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get -y install nodejs npm
 
 # Install LaTeX

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM vimc/orderly.server:master
 # install npm
 RUN apt-get update && \
   apt-get -y install curl gnupg && \
+  apt remove --purge nodejs npm && \
+  apt autoclean && \
+  apt install -f && \
   curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get -y install nodejs npm
 


### PR DESCRIPTION
This PR fixes the node installation. Updating the script didn't work, but it turns out the version in ubuntu that we have here is fine