### PR TITLE
Add packages used in paper-second-figures

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN install2.r --error \
   RColorBrewer \
   RcppRoll \
   captioner \
+  circlize \
   dplyr \
   drat \
   flextable \
@@ -74,8 +75,12 @@ RUN install2.r --error \
   markdown \
   officer \
   pander \
+  pheatmap \
   readxl \
   rgdal \
+  rgeos \
+  rnaturalearth \
+  scatterpie \
   spelling \
   stackoverflow \
   tidyr \
@@ -90,6 +95,7 @@ RUN install2.r --repo "https://vimc.github.io/drat" \
   orderlyweb
 
 RUN Rscript -e 'remotes::install_github("vimc/vimpact")'
+RUN Rscript -e 'remotes::install_github("jokergoo/ComplexHeatmap")'
 
 COPY docker/install_jenner /tmp/install_jenner
 RUN /tmp/install_jenner && rm -f /tmp/install_jenner

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install -y \
 
 # Add new packages here (in alphabetical order)
 RUN install2.r --error \
+  CoordinateCleaner \  
   DT \
   FinCal \
   RColorBrewer \


### PR DESCRIPTION
Susy reported
```
orderly::orderly_run_remote("paper-second-figures",  remote = "production")
Error in stop_missing_packages(missing_packages) :                                                                
  Missing packages: 'rnaturalearth', 'rgeos', 'pheatmap', 'scatterpie', 'ComplexHeatmap', 'circlize'
To install the missing packages run:
    install.packages(c('rnaturalearth', 'rgeos', 'pheatmap', 'scatterpie', 'ComplexHeatmap', 'circlize'))
Calls: tryCatch ... check_missing_packages -> handle_missing_packages -> stop_missing_packages
Execution halted
Error: Report has failed: see above for details
```