### PR TITLE
vimc-4604 Add extrafont to installed R packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN install2.r --error \
   circlize \
   dplyr \
   drat \
+  extrafont \
   flextable \
   foreach \
   gert \


### PR DESCRIPTION
This package is used by a few montagu reports: https://github.com/vimc/montagu-reports/search?q=extrafont